### PR TITLE
fix missing rxjs import

### DIFF
--- a/src/spell-check-handler.js
+++ b/src/spell-check-handler.js
@@ -7,6 +7,7 @@ import {Observable} from 'rxjs/Observable';
 import {Subject} from 'rxjs/Subject';
 import SerialSubscription from 'rxjs-serial-subscription';
 
+import 'rxjs/add/observable/merge';
 import 'rxjs/add/observable/defer';
 import 'rxjs/add/observable/empty';
 import 'rxjs/add/observable/fromEvent';


### PR DESCRIPTION
This is for prevent `Property 'merge' does not exist on type 'typeof Observable'` errors.
Please see: https://github.com/ReactiveX/rxjs/issues/1694